### PR TITLE
use wct-config-vaadin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stylelint-config-vaadin": "^0.1.4",
     "wct-istanbul": "^0.14.3",
     "wct-random-output": "^0.2.0",
+    "wct-config-vaadin": "^0.1.0",
     "web-component-tester": "^6.7.0"
   }
 }


### PR DESCRIPTION
Most Vaadin components use Web Component Tester to run tests. Every repo has its own copy of the WCT config and that leads to inconsistencies (especially in the list of SauceLabs platforms). It would be easier to maintain and update the WCT configs in all Vaadin Components if they were using the same default WCT config as a base.

There are 2 PRs and 1 new repo that together make up this change:
 - create a new npm package / new GitHub repo to keep the default Vaadin Web Component Tester config: https://github.com/vaadin/wct-config-vaadin
   _It needs to be released to npm first before the PRs can be merged._
 - [this PR] update the `vaadin-component-dev-dependencies` meta package to include `wct-config-vaadin`: https://github.com/vaadin/vaadin-component-dev-dependencies/pull/2
 - update `vaadin-element-skeleton` to use the WCT config from the `wct-config-vaadin` package: https://github.com/vaadin/vaadin-element-skeleton/pull/164