### PR TITLE
fix: bump magi-cli to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint-config-vaadin": "^0.2.7",
     "eslint-plugin-html": "^5.0.0",
     "husky": "^1.3.1",
-    "magi-cli": "^0.23.0",
+    "magi-cli": "^0.29.2",
     "npm-run-all": "^4.1.5",
     "stylelint": "^9.0.0",
     "stylelint-config-vaadin": "^0.1.4",


### PR DESCRIPTION
## Description

There happens to be a misalignment with `magi-cli` installed locally (0.23.0) vs global one (0.29.2)
In some cases it causes a problem related to missing version getter when running `npm version`.

Updated this package to contain the latest version of magi in order to fix this problem.