### PR TITLE
fix: update magi-cli version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint-config-vaadin": "^0.2.7",
     "eslint-plugin-html": "^5.0.0",
     "husky": "^1.3.1",
-    "magi-cli": "^0.29.2",
+    "magi-cli": "^1.0.0",
     "npm-run-all": "^4.1.5",
     "stylelint": "^9.0.0",
     "stylelint-config-vaadin": "^0.1.4",


### PR DESCRIPTION
## Description

This should be done in a patch release to avoid updating all the components.